### PR TITLE
Add dark mode toggle and styling

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -5,6 +5,10 @@
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
         <button><div class="navicon"></div></button>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
+          <i class="fas fa-moon moon-icon"></i>
+          <i class="fas fa-sun sun-icon"></i>
+        </button>
         <ul class="visible-links">
           <li class="masthead__menu-item masthead__menu-item--lg"><a href="{{ base_path }}/">{{ site.title }}</a></li>
           {% for link in site.data.navigation.main %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
 <script src="{{ base_path }}/assets/js/main.min.js"></script>
 <script src="{{ base_path }}/assets/js/unified-search.js"></script>
 
+<script src="{{ base_path }}/assets/js/theme-toggle.js"></script>
 {% include analytics.html %}
 {% include /comments-providers/scripts.html %}

--- a/_sass/_dark-theme.scss
+++ b/_sass/_dark-theme.scss
@@ -1,0 +1,54 @@
+:root {
+  --background-color: #ffffff;
+  --text-color: #000000;
+  --link-color: #0366d6;
+  --masthead-background: #ffffff;
+  --footer-background: #f0f0f0;
+  --footer-border: #e0e0e0;
+}
+
+[data-theme="dark"] {
+  --background-color: #121212;
+  --text-color: #e4e4e4;
+  --link-color: #58a6ff;
+  --masthead-background: #1e1e1e;
+  --footer-background: #1e1e1e;
+  --footer-border: #333333;
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+a {
+  color: var(--link-color);
+}
+
+.masthead {
+  background-color: var(--masthead-background);
+  color: var(--text-color);
+}
+
+.page__footer {
+  background-color: var(--footer-background);
+  border-top: 1px solid var(--footer-border);
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.theme-toggle .sun-icon {
+  display: none;
+}
+
+[data-theme="dark"] .theme-toggle .sun-icon {
+  display: inline;
+}
+
+[data-theme="dark"] .theme-toggle .moon-icon {
+  display: none;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,3 +39,5 @@
 @import "vendor/font-awesome/brands";
 @import "vendor/magnific-popup/magnific-popup";
 @import "print";
+@import "dark-theme";
+

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const storageKey = 'theme';
+  const toggle = document.getElementById('theme-toggle');
+  const sunIcon = toggle?.querySelector('.sun-icon');
+  const moonIcon = toggle?.querySelector('.moon-icon');
+  const root = document.documentElement;
+
+  function applyTheme(theme) {
+    if (theme === 'dark') {
+      root.setAttribute('data-theme', 'dark');
+      if (sunIcon) sunIcon.style.display = 'inline';
+      if (moonIcon) moonIcon.style.display = 'none';
+    } else {
+      root.removeAttribute('data-theme');
+      if (sunIcon) sunIcon.style.display = 'none';
+      if (moonIcon) moonIcon.style.display = 'inline';
+    }
+  }
+
+  function getPreferredTheme() {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      return stored;
+    }
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  let currentTheme = getPreferredTheme();
+  applyTheme(currentTheme);
+
+  toggle?.addEventListener('click', () => {
+    currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    localStorage.setItem(storageKey, currentTheme);
+    applyTheme(currentTheme);
+  });
+});


### PR DESCRIPTION
## Summary
- add theme toggle button and script
- define dark theme variables and styles
- load toggle script on all pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688daba65b4883248ec29919fd826624